### PR TITLE
Disable schema creation using JPA

### DIFF
--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -25,9 +25,6 @@ spring:
     clean-disabled: false
   thymeleaf:
     prefix: classpath:/templates/
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
   main:
     allow-circular-references: true
   session:


### PR DESCRIPTION
Schema creation should be left to Flyway. This is a familiar problem that was also encountered in the form-flow library.