### PR TITLE
Change accepted file types based on feedback

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ form-flow:
   path: 'flows-config.yaml'
   uploads:
     default-doc-type-label: "NotSet"
-    accepted-file-types: '.jpeg,.jpg,.png,.pdf,.bmp,.gif,.doc,.docx,.odt,.ods,.odp'
+    accepted-file-types: '.doc,.docx,.pdf,.xls,.xlsx,.ppt,.pptx,.txt,.csv'
     thumbnail-width: '64'
     thumbnail-height: '60'
     # 20 files maximum

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1178,7 +1178,7 @@ doc-upload-recommendations.residency-content=Current official document with your
 doc-upload-recommendations.identity=Proof of Identity
 doc-upload-recommendations.identity-content=A government-issued photo ID such as a driver's license, identity card, passport or Social Security card.
 doc-upload-recommendations.types-of-files=Types of files
-doc-upload-recommendations.types-of-files-content=We accept .jpeg, .jpg, .png, .pdf, .bmp, .gif, .doc, .docx, .odt, .ods, or .odp files. Each file is limited to 20MB. The maximum number of files is 20.
+doc-upload-recommendations.types-of-files-content=We accept {0} files. Each file is limited to {1} MB. The maximum number of files is {2}.
 
 
 # doc upload signpost

--- a/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
+++ b/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
@@ -9,15 +9,19 @@
                       </span>
       <span th:text="#{doc-upload-recommendations.recommended}"></span>
     </th:block>
-    <th:block th:ref="revealContent1">
-      <b th:text="#{doc-upload-recommendations.income}"></b>
-      <p th:text="#{doc-upload-recommendations.income-content}"></p>
-      <b th:text="#{doc-upload-recommendations.residency}"></b>
-      <p th:text="#{doc-upload-recommendations.residency-content}"></p>
-      <b th:text="#{doc-upload-recommendations.identity}"></b>
-      <p th:text="#{doc-upload-recommendations.identity-content}"></p>
-      <b th:text="#{doc-upload-recommendations.types-of-files}"></b>
-      <p th:text="#{doc-upload-recommendations.types-of-files-content}"></p>
+    <th:block th:ref="revealContent1"
+              th:with="
+                  maxFiles=${@environment.getProperty('form-flow.uploads.max-files')},
+                  maxFileSize=${@environment.getProperty('form-flow.uploads.max-file-size')},
+                  fileTypes=${@environment.getProperty('form-flow.uploads.accepted-file-types')}">
+        <b th:text="#{doc-upload-recommendations.income}"></b>
+        <p th:text="#{doc-upload-recommendations.income-content}"></p>
+        <b th:text="#{doc-upload-recommendations.residency}"></b>
+        <p th:text="#{doc-upload-recommendations.residency-content}"></p>
+        <b th:text="#{doc-upload-recommendations.identity}"></b>
+        <p th:text="#{doc-upload-recommendations.identity-content}"></p>
+        <b th:text="#{doc-upload-recommendations.types-of-files}"></b>
+        <p th:text="#{doc-upload-recommendations.types-of-files-content(${fileTypes}, ${maxFileSize}, ${maxFiles})}"></p>
     </th:block>
   </th:block>
 </th:block>


### PR DESCRIPTION
This also makes the message for what file types are acceptable in the information reveal dynamic.  It was a static message that now will not need to be changed if the file types, etc change again.

Based on feedback on this ticket: https://www.pivotaltracker.com/story/show/186854106