### PR TITLE
Make doc uploader use an accordion versus reveal

### DIFF
--- a/src/main/resources/templates/fragments/accordion.html
+++ b/src/main/resources/templates/fragments/accordion.html
@@ -1,0 +1,15 @@
+<th:block
+    th:fragment="accordion"
+    th:with="controlId=${controlId == null ? 'a1' : controlId}"
+    th:assert="
+      ${!#strings.isEmpty(buttonLabel)},
+      ${!#strings.isEmpty(content)}">
+  <div class="accordion">
+    <button class="accordion__button" aria-expanded="true" aria-controls="controlId">
+      <th:block th:replace="${buttonLabel}"/>
+    </button>
+    <div class="accordion__content" id="controlId">
+      <th:block th:replace="${content}"/>
+    </div>
+  </div>
+</th:block>

--- a/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
+++ b/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
@@ -1,7 +1,7 @@
 <th:block th:fragment="docUploadSeeWhatToAddReveal">
   <th:block th:replace="~{fragments/accordion :: accordion(
     buttonLabel=~{::contentLabel},
-    content=~{::contentContent})}">
+    content=~{::content})}">
     <th:block th:ref="contentLabel">
                       <span class="clipboard-icon">
                         <i class="icon-">&#xE862;</i>

--- a/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
+++ b/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
@@ -1,9 +1,8 @@
 <th:block th:fragment="docUploadSeeWhatToAddReveal">
-  <th:block th:replace="~{'fragments/honeycrisp/reveal' :: reveal(
-                  controlId='r1',
-                  linkLabel=~{::revealLabel1},
-                  content=~{::revealContent1})}">
-    <th:block th:ref="revealLabel1">
+  <th:block th:replace="~{fragments/accordion :: accordion(
+    buttonLabel=~{::contentLabel},
+    content=~{::contentContent})}">
+    <th:block th:ref="contentLabel">
                       <span class="clipboard-icon">
                         <i class="icon-">&#xE862;</i>
                       </span>

--- a/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
+++ b/src/main/resources/templates/fragments/docUploadSeeWhatToAddReveal.html
@@ -8,7 +8,7 @@
                       </span>
       <span th:text="#{doc-upload-recommendations.recommended}"></span>
     </th:block>
-    <th:block th:ref="revealContent1"
+    <th:block th:ref="content"
               th:with="
                   maxFiles=${@environment.getProperty('form-flow.uploads.max-files')},
                   maxFileSize=${@environment.getProperty('form-flow.uploads.max-file-size')},


### PR DESCRIPTION
This also overrides the honeycrisp version of the accordion so that we can pass it an html item versus just text.

This should complete https://www.pivotaltracker.com/story/show/186854106