### PR TITLE
Make demo be a manual deploy, versus automatic

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -1,8 +1,6 @@
 name: Deploy to Aptible Demo
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     inputs: { }
 


### PR DESCRIPTION
If demo is mean to track prod, we need to make sure it doesn't update automatically and only when we are ready to demo a new feature/change.