### PR TITLE
Remove household total income from income summary screen

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -625,7 +625,6 @@ income-list.monthly-income=Your monthly household income
 income-list.continue=I'm done adding jobs
 income-list.box-title=Your monthly household income
 income-list.total-income=Total monthly household income
-income-list.total-monthly-pay=Total monthly household income
 income-list.no-jobs-added=No jobs added
 income-list.thats-you=(that's you!)
 income-list.delete-job=delete job

--- a/src/main/resources/templates/mdBenefitsFlow/householdIncomeList.html
+++ b/src/main/resources/templates/mdBenefitsFlow/householdIncomeList.html
@@ -70,23 +70,6 @@
                         <span th:text="#{income-list.no-jobs-added}"></span>
                       </div>
                     </th:block>
-
-                    <th:block th:if="${incomeItem.get('itemType').equals('household-total')}">
-                      <hr>
-                      <span class="subflow-list__icon">
-                    <th:block th:replace="~{'fragments/icons' :: iconHouseOutlineTiny}"/>
-                    </span>
-
-                      <span class="subflow-list__icon">
-                    </span>
-                      <div class="subflow-list__item-title">
-                        <span th:text="#{income-list.total-monthly-pay}"></span>
-                      </div>
-
-                      <div class="subflow-list__item-body">
-                        <div><span th:text="${incomeItem.income}"></span></div>
-                      </div>
-                    </th:block>
                   </li>
                 </ul>
 


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/n/projects/2688497/stories/187222921

Removes the total from the html template, and deletes the now-unused message for that section