### PR TITLE
Hide the expedited snap notification page.

### DIFF
--- a/src/main/resources/flows-config.yaml
+++ b/src/main/resources/flows-config.yaml
@@ -20,10 +20,12 @@ flow:
       - name: choosePrograms
   choosePrograms:
     nextScreens:
-      - name: expeditedSnapNotice
-  expeditedSnapNotice:
-    condition: ProgramsIncludeSnap
-    nextScreens:
+      # we are not doing expeditedSnap during the first phase, but leaving this in
+      # for v1.5 phase
+      #      - name: expeditedSnapNotice
+      #  expeditedSnapNotice:
+      #    condition: ProgramsIncludeSnap
+      #    nextScreens:
       - name: ohepNotice
   ohepNotice:
     condition: ProgramsIncludeSnapOrTCA

--- a/src/test/java/org/mdbenefits/app/journeys/MdBenefitsFlowJourneyTest.java
+++ b/src/test/java/org/mdbenefits/app/journeys/MdBenefitsFlowJourneyTest.java
@@ -462,8 +462,9 @@ public class MdBenefitsFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
 
         // Expedited Snap Notice
-        assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
-        testPage.clickContinue();
+        // taking this out for now, as we have disabled expedited snap for the time being
+        //assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
+        //testPage.clickContinue();
 
         // OHEP Notice
         assertThat(testPage.getTitle()).isEqualTo(message("ohep-notice.title"));

--- a/src/test/java/org/mdbenefits/app/journeys/MdBenefitsFlowJourneyTest.java
+++ b/src/test/java/org/mdbenefits/app/journeys/MdBenefitsFlowJourneyTest.java
@@ -98,8 +98,8 @@ public class MdBenefitsFlowJourneyTest extends AbstractBasePageTest {
         testPage.clickContinue();
 
         // Expedited Snap Notice
-        assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
-        testPage.clickContinue();
+        // assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
+        // testPage.clickContinue();
 
         // OHEP Notice
         assertThat(testPage.getTitle()).isEqualTo(message("ohep-notice.title"));
@@ -144,8 +144,8 @@ public class MdBenefitsFlowJourneyTest extends AbstractBasePageTest {
 
         testPage.clickElementById("programs-SNAP");
         testPage.clickContinue();
-        assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
-        testPage.clickContinue();
+        //assertThat(testPage.getTitle()).isEqualTo(message("expedited-snap-notice.title"));
+        //testPage.clickContinue();
         assertThat(testPage.getTitle()).isEqualTo(message("ohep-notice.title"));
         testPage.clickButton("Ok, thanks");
         assertThat(testPage.getTitle()).isEqualTo(message("how-this-works.title"));


### PR DESCRIPTION
Addresses the 2nd part of: https://www.pivotaltracker.com/story/show/187270727

The boxes are already out of the PDF file. That was done in a separate [PR](https://github.com/codeforamerica/mdpilot/pull/145)
