### PR TITLE
Modify configuration to update session timeout.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,9 @@ form-flow:
       domain: 'mg.marylandbenefits.org'
       sender-email: 'Maryland Benefits <help@marylandbenefits.org>'
 spring:
+  messages:
+    encoding: ISO-8859-1
+    basename: messages, messages-form-flow
   flyway:
     placeholders:
       uuid_function: "gen_random_uuid"
@@ -46,18 +49,11 @@ spring:
       test:
         - test
         - form-flow-library-test
-      dev:
-        - dev
-        - form-flow-library
-      demo:
-        - demo
-        - form-flow-library
-      staging:
-        - staging
-        - form-flow-library
-      prod:
-        - prod
-        - form-flow-library
+    # NOTE: we removed the other profile groups as we were finding that
+    # the form flow library's file was overriding ours, rather than the
+    # other way around.  We copied in the form flow library's configuration
+    # here, so it's still here.  We are disconnected from the
+    # form flow library's file now and need to keep an eye on that.
   thymeleaf:
     cache: false
     template-resolver-order: 0
@@ -78,6 +74,13 @@ spring:
     multipart:
       max-file-size: ${form-flow.uploads.max-file-size}MB
       max-request-size: ${form-flow.uploads.max-file-size}MB
+  session:
+    timeout: 30M
+    store-type: jdbc
+    jdbc:
+      initialize-schema: always
+  jpa:
+    open-in-view: false
 logging:
   level:
     root: INFO


### PR DESCRIPTION
Co-Authored-By: Shawn Tabai <stabai@codeforamerica.org

Addresses: https://www.pivotaltracker.com/story/show/186967548

This disconnects us from the form flow library yaml configuration as that was actually getting in the way here, sadly.
We copied in all the form flow library configuration into our `application.yaml` configuration.    

To test this, you can look at the spring_session table and ensure that the `max_inactive_interval` is set to 30M. And you can play with that time and see it change.  