### PR TITLE
Remove amount requirement for inputs 187359678

### DIFF
--- a/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
+++ b/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
@@ -239,46 +239,32 @@ public class MdBenefitsFlow extends FlowInputs {
     private List<String> householdHomeExpenses;
 
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseRent;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseMortgage;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpensePhone;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseElectricity;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseWater;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseSewer;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseGarbage;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseGas;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseOil;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseWoodOrCoal;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseCondominiumFees;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpensePropertyTax;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseHomeownerInsurance;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String homeExpenseOtherHomeExpenses;
 
     private List<String> ohepRentSituations;

--- a/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
+++ b/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
@@ -300,31 +300,22 @@ public class MdBenefitsFlow extends FlowInputs {
     private List<String> medicalExpenses;
 
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseHealthMedicalInsurance;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseDenturesGlassesEtc;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseHospitalBills;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseAttendantCare;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseMedicalDentalInsurance;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseTransportationCosts;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseNursing;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpensePharmacy;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String medicalExpenseOther;
 
     private String hasDependentCareExpenses;

--- a/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
+++ b/src/main/java/org/mdbenefits/app/inputs/MdBenefitsFlow.java
@@ -196,34 +196,24 @@ public class MdBenefitsFlow extends FlowInputs {
     private List<String> additionalIncome;
 
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeAlimony;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeChildSupport;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeFriendsAndFamily;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomePensionRetirement;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeSSI;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeSS;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeUnemployment;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeVeteransBenefits;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeWorkersComp;
     @Money(message = "{error.invalid-money}")
-    @NotEmpty(message = "{error.missing-general}")
     private String additionalIncomeOther;
 
     @NotEmpty


### PR DESCRIPTION
This PR makes the following functionality:
- When a user selects household expenses, medical expenses, or additional incomes
- They are asked to provide a $ value on the follow up page
- The user can move forward as the $ values are not longer required
    - If the user inputs the values of 0, they will not see an error message
    - If the user inputs any value that is not a digit, they will be an error message
    - If the user inputs values that do not match this pattern (X.XX, X) they will see an error message
 - In the PDF, we will see a blank space when the user did not input $ value data