### PR TITLE
fix spacing on household details screen

### DIFF
--- a/src/main/resources/static/assets/css/custom.css
+++ b/src/main/resources/static/assets/css/custom.css
@@ -44,11 +44,11 @@ body {
 }
 
 .subflow-edit {
-  color: #008060 !important;
+  color: #003865 !important;
 }
 
 .subflow-delete {
-  color: #D13F00 !important;
+  color: #003865 !important;
 }
 
 .subflow-list__item-actions a:not(:last-child) {


### PR DESCRIPTION
Addresses:  https://www.pivotaltracker.com/story/show/187121194

This is only partially fixed - the link color is changed, but I'm unsure how to make the spans look nice. I suspect it depends on the length of the the text the span is covering. Not sure if we are tying to avoid tables, but a table could lend nice formatting here. 